### PR TITLE
Support for two networks + corresponding clean-up of CONACQv1 implementation

### DIFF
--- a/src/fr/lirmm/coconut/acquisition/core/acqconstraint/ACQ_Network.java
+++ b/src/fr/lirmm/coconut/acquisition/core/acqconstraint/ACQ_Network.java
@@ -213,7 +213,7 @@ public class ACQ_Network implements Iterable<ACQ_IConstraint> {
 	 * @param query Example
 	 * @return false if query violates at least one constraint of this network
 	 */
-	boolean check(ACQ_Query query) {
+	public boolean check(ACQ_Query query) {
 		for (ACQ_IConstraint constraint : constraints) {
 			if (query.getScope().containsAll(constraint.getScope())
 					&& !constraint.checker(constraint.getProjection(query))) {

--- a/src/fr/lirmm/coconut/acquisition/core/algorithms/ACQ_CONACQv1.java
+++ b/src/fr/lirmm/coconut/acquisition/core/algorithms/ACQ_CONACQv1.java
@@ -25,10 +25,7 @@ import fr.lirmm.coconut.acquisition.core.acqsolver.ACQ_ConstraintSolver;
 import fr.lirmm.coconut.acquisition.core.acqsolver.ACQ_IDomain;
 import fr.lirmm.coconut.acquisition.core.acqsolver.SATModel;
 import fr.lirmm.coconut.acquisition.core.acqsolver.SATSolver;
-import fr.lirmm.coconut.acquisition.core.learner.ACQ_Bias;
-import fr.lirmm.coconut.acquisition.core.learner.ACQ_Learner;
-import fr.lirmm.coconut.acquisition.core.learner.ACQ_Query;
-import fr.lirmm.coconut.acquisition.core.learner.ACQ_Scope;
+import fr.lirmm.coconut.acquisition.core.learner.*;
 import fr.lirmm.coconut.acquisition.core.tools.Chrono;
 import fr.lirmm.coconut.acquisition.core.tools.FileManager;
 
@@ -52,8 +49,11 @@ public class ACQ_CONACQv1 {
 	protected int max_random = 0;
 	protected int n_asked = 0;
 	protected ArrayList<ACQ_Query> queries;
-	
-	
+	protected ACQ_CNF T;
+	protected ContradictionSet N;
+
+	protected ACQ_Network mostGeneralNetwork = null;
+	protected ACQ_Network mostSpecificNetwork = null;
 	
 	public ACQ_CONACQv1(ACQ_Learner learner, ACQ_Bias bias, SATSolver sat, ACQ_ConstraintSolver solv,String queries) {
 		this.bias = bias;
@@ -164,108 +164,7 @@ public class ACQ_CONACQv1 {
 
 		this.log_queries = logqueries;
 	}
-	
-	public ACQ_Query query_gen(ACQ_CNF T, ContradictionSet N) throws Exception {
-		ACQ_Query q = new ACQ_Query();
-		ACQ_Clause alpha = new ACQ_Clause();
-		int epsilon = 0;
-		int t = 0;
-		boolean skip_buildformula = false;
-		ACQ_Formula form = null;
-		Boolean splittable = null;
-		while (q.isEmpty() && !T.isMonomial()) {
-			if (!skip_buildformula) {
-				ACQ_Clause newalpha;
-				
-				if (alpha.isEmpty() && !(newalpha = T.getUnmarkedNonUnaryClause()).isEmpty()) {
-					alpha = newalpha;
-					epsilon = 0;
-					//TODO value depending on strategy
-					t = 1; // Optimal in expectation
-					//t = Math.max(alpha.getSize() -1, 1); // Optimistic
-				}
-				splittable = (!alpha.isEmpty() && ((t+epsilon < alpha.getSize()) || (t - epsilon > 0)));
-				chrono.start("build_formula");
-				form = BuildFormula(splittable, T, N, alpha, t, epsilon);
-				chrono.stop("build_formula");
-				assert(form != null);
-				form.addCnf(N.toCNF());
-			}
-			skip_buildformula = false;
-			SATModel model = satSolver.solve(form);
-			
-			if (satSolver.isTimeoutReached()) {
-				assert(q.isEmpty());
-				return q; // Collapse
-			}
-			
-			if (model == null) {
-				assert !alpha.isEmpty() : "invariant: alpha should not be empty";
-				
-				if (splittable) {
-					epsilon += 1;
-				}
-				
-				else {
-					T.remove(alpha);
-					for (Unit unit : alpha) {
-						assert !unit.isNeg() : "literals in alpha should not be negated";
-						T.add(new ACQ_Clause(unit));
-					}
-					T.unitPropagate(chrono);
-					alpha = new ACQ_Clause(); //Empty clause 
-					assert alpha.isEmpty() : "The empty clause should be empty";
-				}
-			}
-			else {
-				ACQ_Network network = toNetwork(model);
-				q = constrSolver.solveQ(network);
-				
-				if (constrSolver.isTimeoutReached()) {
-					assert q.isEmpty() : "Timeout reached but q is not empty";
-					return q;
-				}
-				
-				if (q.isEmpty()) {
-					boolean oneContradictiononly = true;
-					if (oneContradictiononly) {
-						Contradiction unsatCore = quickExplain(new ACQ_Network(constraintFactory, bias.network.getVariables()), network);
-						assert (unsatCore != null && !unsatCore.isEmpty());
-						N.add(unsatCore);
-						if (!alpha.isEmpty()) {
-							// Here splittalbe, alpha (!= empty) and T does not change (only N change) 
-							// so BuildFormula will return the same formula 
-							skip_buildformula = true; // Here splittalbe, alpha (!= empty) and T does not change (only N change) so BuildFormula 
-						}
-					}
-					else {
-						int i = 0;
-						while (!isConsistent(network)) {
-							Contradiction unsatCore = quickExplain(new ACQ_Network(constraintFactory, bias.network.getVariables()), network);
-							if (unsatCore == null || unsatCore.isEmpty())
-								break;
-							N.add(unsatCore);
-							i += 1;
-							for (ACQ_IConstraint constr : unsatCore.toNetwork()) {
-								network.remove(constr);
-							}
-						}
-						assert i > 0 : "No contradictions added";
-					}
-				}
-				else {
-					if (!splittable && !alpha.isEmpty())
-						alpha.mark();
-				}
-				
-			}
-			
-		}
-		if (q.isEmpty())
-			q = irredundantQuery(T);
-		return q;
-	}
-	
+
 	protected ACQ_Formula BuildFormula(Boolean splittable, ACQ_CNF T, ContradictionSet N, ACQ_Clause alpha, int t, int epsilon) {
 		ACQ_Formula res =  new ACQ_Formula();
 		if (!alpha.isEmpty()) {
@@ -334,191 +233,18 @@ public class ACQ_CONACQv1 {
 		
 		return satSolver.solve(tmp1) != null && satSolver.solve(tmp2) != null;
 	}
-	
-	protected ACQ_Query irredundantQuery(ACQ_CNF T) {
-		assert(T.isMonomial());
-		ACQ_Network learned = new ACQ_Network(constraintFactory, bias.getVars(), constraintFactory.createSet(T.getMonomialPositive()));
-		
-		long startTime = System.currentTimeMillis();
-		while(System.currentTimeMillis() - startTime < 100) { // Until 0.1 second timeout
-			ACQ_Query q = constrSolver.solveQ(learned);
-			
-			ConstraintSet kappa = bias.getKappa(q);
-			for(ACQ_Clause clause : T) {
-				Unit unit = clause.get(0);
-				if (unit.isNeg())
-					kappa.remove(unit.getConstraint());
-			}
-			
-			if(kappa.size() > 0) {
-				return q;
-			}
-		}
-		
-		for(ACQ_IConstraint c : bias.getConstraints()) {
-			if (!learned.contains(c)) {
-				learned.add(c.getNegation(), true);
-				ACQ_Query q = constrSolver.solveQ(learned);
-				learned.remove(c.getNegation());
-				if(!q.isEmpty())
-					return q;
-				else
-					T.add(new ACQ_Clause(mapping.get(c)));
-			}
-		}
-		return new ACQ_Query();
-	}
-	
-	protected Contradiction quickExplain(ACQ_Network b, ACQ_Network network) {
-		chrono.start("quick_explain");
-		Contradiction result;
-		if (network.size() == 0) {
-			result = new Contradiction(new ACQ_Network());
-		}
-		else {
-			ACQ_Network res = quick(b, b, network);
-			assert !isConsistent(res) : "quickExplain must returned inconsistent networks";
-			result = new Contradiction(res);
-		}
-		chrono.stop("quick_explain");
-		return result;
-	}
-	
-	protected ACQ_Network quick(ACQ_Network b, ACQ_Network delta, ACQ_Network c) {
-		//System.out.println("In");
-		if(delta.size() != 0 && !isConsistent(b)) {
-			return new ACQ_Network(c.getFactory(), c.getFactory().createSet());
-		}
-		if(c.size() == 1) 
-			return c;
-		
-		ACQ_Network c1 = new ACQ_Network(constraintFactory, bias.network.getVariables()); 
-		ACQ_Network c2 = new ACQ_Network(constraintFactory, bias.network.getVariables());
-		
-		int i=0;
-		for (ACQ_IConstraint constr : c.getConstraints()) {
-			if(i < c.size()/2) {
-				c1.add(constr, true);
-			}
-			else {
-				c2.add(constr, true);
-			}
-			i+=1;
-		}
-		
-		ACQ_Network b_union_c1 = new ACQ_Network(constraintFactory, b, bias.network.getVariables());
-		b_union_c1.addAll(c1, true);
-		ACQ_Network delta2 = quick(b_union_c1, c1, c2);
-		
-		ACQ_Network b_union_delta2 = new ACQ_Network(constraintFactory, b, bias.network.getVariables());
-		b_union_delta2.addAll(delta2, true);
-		ACQ_Network delta1 = quick(b_union_delta2, delta2, c1);
-		
-		delta1.addAll(delta2, true);
-		return delta1;
-	}
 
 	protected Boolean isConsistent(ACQ_Network network) {
 		return constrSolver.solve(network);
 	}
 	
-	
-	protected ACQ_Query preproc_query_gen(int n_random) {
-		if (this.strategy != null && this.strategy.size() > 0) {
-			ACQ_Network s = this.strategy.get(0);
-			this.strategy.remove(0);
-			return constrSolver.solveQ(s);
-		} else if (n_random < max_random){
-			ACQ_Scope scope = bias.getVars();
-			Random random = new Random();
-			int values[] = new int [scope.size()]; 
-			for (int i = 0; i < values.length; i++) {
-				values[i] = random.nextInt(domain.getMax(i)+1);
-			}
-			return new ACQ_Query(scope, values);
-		}
-		else {
-			return new ACQ_Query();
-		}
-	}
-	
-	protected boolean preprocess(ACQ_CNF T, ContradictionSet N, int max_queries) throws Exception {
-		boolean collapse = false;
-		boolean stop = false;
-		int oldbias_size = bias_size_before_preprocess;
-		
-		int n_random = 0;
-		
-		for(ACQ_Query membership_query : queries){
 
-			if (bias.getConstraints().isEmpty())
-				break;
-			
-			assert membership_query != null : "membership query can't be null";
-			
-			
-			if(constrSolver.isTimeoutReached() || satSolver.isTimeoutReached()) {
-				collapse = true;
-				break;
-			}
-		
-			if (membership_query.isEmpty()) {
-				stop = true;
-			}
-			else {
-				if (verbose) System.out.print("[PREPROC] " + membership_query.getScope() +"::"+ Arrays.toString(membership_query.values));
-				boolean answer = membership_query.isPositive();
-				n_asked++;
-				ConstraintSet kappa = bias.getKappa(membership_query);
-				if (verbose) System.out.println("::" + membership_query.isPositive());
-				if(kappa.size() > 0) {
-					if (answer) {
-						for (ACQ_IConstraint c : kappa) {
-							Unit unit = mapping.get(c).clone();
-							unit.setNeg();
-							T.unitPropagate(unit, chrono);
-							N.unitPropagate(unit, chrono);
-						}
-						bias.reduce(kappa);
-					}
-					else {
-						if (kappa.size() == 1) {
-							ACQ_IConstraint c = kappa.get_Constraint(0);
-							Unit unit = mapping.get(c).clone();
-							T.unitPropagate(unit, chrono);
-							N.unitPropagate(unit, chrono);
-							bias.reduce(c.getNegation());
-						}
-						else {
-							ACQ_Clause disj = new ACQ_Clause();
-							for (ACQ_IConstraint c: kappa) {
-								Unit unit = mapping.get(c).clone();
-								disj.add(unit);
-							}
-							T.addChecked(disj);
-						}
-					}
-				}
-				
-				if (oldbias_size >= bias.getSize()) {
-					n_random++;
-				}
-				else {
-					oldbias_size = bias.getSize();
-					n_random = 0;
-				}
-			}
-		}
-		
-		return collapse;
-	}
-	
 	public boolean process(Chrono chronom, int max_queries) throws Exception {
 		chrono = chronom;
 		boolean convergence = false;
 		boolean collapse = false;
-		ACQ_CNF T = new ACQ_CNF();
-		ContradictionSet N;
+		T = new ACQ_CNF();
+
 		if (this.backgroundKnowledge == null) {
 			N = new ContradictionSet(constraintFactory, bias.network.getVariables(), mapping);
 		} else {
@@ -618,6 +344,43 @@ public class ACQ_CONACQv1 {
 
 		return !collapse;
 	}
+
+	public Classification classify(ACQ_Query query) {
+		updateNetworks();
+
+		boolean isCompleteQuery = true;
+
+		if (isCompleteQuery) {
+			boolean generalAccepts = mostGeneralNetwork.check(query);
+			boolean specificAccepts = mostSpecificNetwork.check(query);
+		}
+		return Classification.UNKNOWN;
+	}
+
+	protected void updateNetworks() {
+		assert (T.isMonomial());
+
+		if (mostGeneralNetwork == null) {
+			SATModel model = satSolver.solve(T);
+			mostGeneralNetwork = new ACQ_Network(constraintFactory, bias.getVars());
+
+			for (Unit unit : mapping.values()) {
+				if (!unit.isNeg() && model.get(unit)) {
+					mostGeneralNetwork.add(unit.getConstraint(), true);
+				}
+			}
+		}
+
+		if (mostSpecificNetwork == null) {
+			mostSpecificNetwork = new ACQ_Network(constraintFactory, bias.getVars());
+			for (ACQ_IConstraint constr: bias.getConstraints()) {
+				if (!isUnset(constr, T, N)) {
+					mostSpecificNetwork.add(constr, true);
+				}
+			}
+		}
+	}
+
 	
 	protected ACQ_Network toNetwork(SATModel model) throws Exception {
 		chrono.start("to_network");
@@ -636,5 +399,11 @@ public class ACQ_CONACQv1 {
 	public void setInitN(ACQ_Network InitNetwork) {
 		init_network=InitNetwork;
 	}
-	
+
+	protected ACQ_Query initializeQuery() {
+		// HS Initialize an query with full scope and placeholder values
+		ACQ_Scope vars = bias.getVars();
+		int[] placeholderValues = new int[vars.size()];
+		return new ACQ_Query(vars, placeholderValues);
+	}
 }

--- a/src/fr/lirmm/coconut/acquisition/core/learner/ACQ_Learner.java
+++ b/src/fr/lirmm/coconut/acquisition/core/learner/ACQ_Learner.java
@@ -3,6 +3,7 @@ package fr.lirmm.coconut.acquisition.core.learner;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import fr.lirmm.coconut.acquisition.core.acqconstraint.ACQ_Network;
 
@@ -36,6 +37,17 @@ public class ACQ_Learner implements ILearner {
 	public boolean ask(ACQ_Query e) {
 		// TODO Auto-generated method stub
 		return false;
+	}
+
+	public void answer(Classification result) {
+
+	}
+
+	public Iterable<ACQ_Query> complete(ACQ_Query e) {
+		List<ACQ_Query> res = new ArrayList<>();
+		e.classify(ask(e));
+		res.add(e);
+		return res;
 	}
 
 	/**

--- a/src/fr/lirmm/coconut/acquisition/core/learner/Classification.java
+++ b/src/fr/lirmm/coconut/acquisition/core/learner/Classification.java
@@ -1,0 +1,8 @@
+package fr.lirmm.coconut.acquisition.core.learner;
+
+public enum Classification {
+    POSITIVE,
+    UNKNOWN,
+    NEGATIVE
+}
+


### PR DESCRIPTION
This pull requests adds those changes I initially implemented two support the two networks.
Rather than storing only the clauses, I keep the CNF as a global variable.
There are a few changes regarding to that.
I also removed all code that was necessary for standard conacq but is not applicable in the continuous execution case that we have.

In the learner I add support to receive individual queries that need to be classified.